### PR TITLE
Switch order of default config files: ~ then ./

### DIFF
--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -1457,7 +1457,7 @@ def run(argv=sys.argv):  # pragma: no cover
                  'formatter_class': argparse.ArgumentDefaultsHelpFormatter}
 
     if argparse.__name__ == "configargparse":
-        arguments['default_config_files'] = ['.fprettify.rc', '~/.fprettify.rc']
+        arguments['default_config_files'] = ['~/.fprettify.rc', '.fprettify.rc']
 
     parser = argparse.ArgumentParser(**arguments)
 


### PR DESCRIPTION
Config settings in current directory should override those in home
directory, not the other way around.

https://github.com/bw2/ConfigArgParse/blob/ce4ab38f506a620528d378e61fcbef517f2ef141/configargparse.py#L353-L363