### PR TITLE
feat: add --max-consecutive-empty-lines setting

### DIFF
--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -2027,7 +2027,6 @@ def reformat_inplace(
                 outfile = io.open(filename, "w", encoding="utf-8")
                 outfile.write(newfile.getvalue())
 
-
 def reformat_ffile(
     infile,
     outfile,
@@ -2047,6 +2046,7 @@ def reformat_ffile(
     orig_filename=None,
     indent_fypp=True,
     indent_mod=True,
+    max_consecutive_empty_lines=1,
 ):
     """main method to be invoked for formatting a Fortran file."""
 
@@ -2086,6 +2086,7 @@ def reformat_ffile(
             orig_filename,
             indent_fypp,
             indent_mod,
+            max_consecutive_empty_lines,
         )
         oldfile = newfile
 
@@ -2115,6 +2116,7 @@ def reformat_ffile(
             orig_filename,
             indent_fypp,
             indent_mod,
+            max_consecutive_empty_lines,
         )
 
     outfile.write(newfile.getvalue())
@@ -2139,6 +2141,7 @@ def reformat_ffile_combined(
     orig_filename=None,
     indent_fypp=True,
     indent_mod=True,
+    max_consecutive_empty_lines=1,
 ):
 
     if not orig_filename:
@@ -2177,7 +2180,7 @@ def reformat_ffile_combined(
     nfl = 0  # fortran line counter
     use_same_line = False
     stream = InputStream(infile, not indent_fypp, orig_filename=orig_filename)
-    skip_blank = False
+    number_empty_lines = 0
     in_format_off_block = False
 
     while 1:
@@ -2215,7 +2218,12 @@ def reformat_ffile_combined(
         if prev_indent and indent_special == 0:
             indent_special = 2
 
-        if is_blank and skip_blank:
+        # Find empty line
+        found_empty_line = EMPTY_RE.search(f_line) and not any(comments) and not is_omp_conditional and not label
+        if found_empty_line: number_empty_lines += 1
+        else: number_empty_lines = 0
+
+        if is_blank and number_empty_lines > max_consecutive_empty_lines:
             continue
         if not do_format:
             if indent_special == 2:
@@ -2923,6 +2931,7 @@ def process_args(args):
     args_out["llength"] = 1024 if args.line_length == 0 else args.line_length
     args_out["strip_comments"] = args.strip_comments
     args_out["comment_spacing"] = args.comment_spacing
+    args_out["max_consecutive_empty_lines"] = args.max_consecutive_empty_lines
     args_out["format_decl"] = args.enable_decl
     args_out["indent_fypp"] = not args.disable_fypp
     args_out["indent_mod"] = not args.disable_indent_mod
@@ -3088,6 +3097,12 @@ def get_arg_parser(args={}):
         action="store_true",
         default=False,
         help="don't impose whitespace formatting",
+    )
+    parser.add_argument(
+        "--max-consecutive-empty-lines",
+        type=non_negative_int,
+        default=1,
+        help="set maximum number of consecutive empty lines",
     )
     parser.add_argument(
         "--enable-replacements",
@@ -3342,7 +3357,6 @@ def run(argv=sys.argv):  # pragma: no cover
 
             try:
                 reformat_inplace(filename, **file_args)
-
             except FprettifyException as e:
                 log_exception(e, "Fatal error occured")
                 sys.exit(1)

--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -2317,15 +2317,6 @@ def reformat_ffile_combined(
             allow_split=allow_auto_split,
         )
 
-        # rm subsequent blank lines
-        skip_blank = (
-            EMPTY_RE.search(f_line)
-            and not any(comments)
-            and not is_omp_conditional
-            and not label
-            and not use_same_line
-        )
-
         do_indent, use_same_line = pass_defaults_to_next_line(f_line)
 
         if impose_indent:

--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -2027,6 +2027,7 @@ def reformat_inplace(
                 outfile = io.open(filename, "w", encoding="utf-8")
                 outfile.write(newfile.getvalue())
 
+
 def reformat_ffile(
     infile,
     outfile,
@@ -3348,6 +3349,7 @@ def run(argv=sys.argv):  # pragma: no cover
 
             try:
                 reformat_inplace(filename, **file_args)
+
             except FprettifyException as e:
                 log_exception(e, "Fatal error occured")
                 sys.exit(1)

--- a/fprettify/tests/unittests.py
+++ b/fprettify/tests/unittests.py
@@ -214,6 +214,61 @@ class FprettifyUnitTestCase(FprettifyTestCase):
             outstring_exp_strip_spacing3,
         )
 
+    def test_max_consecutive_empty_lines(self):
+        """test limiting consecutive empty lines"""
+        instring = (
+            "program demo\n"
+            "\n"
+            "\n"
+            "\n"
+            "   a = 1\n"
+            "\n"
+            "\n"
+            "\n"
+            "   b = 2\n"
+            "\n"
+            "\n"
+            "end program demo\n"
+        )
+
+        outstring_exp_default = (
+            "program demo\n"
+            "\n"
+            "   a = 1\n"
+            "\n"
+            "   b = 2\n"
+            "\n"
+            "end program demo\n"
+        )
+
+        outstring_exp_zero = (
+            "program demo\n"
+            "   a = 1\n"
+            "   b = 2\n"
+            "end program demo\n"
+        )
+
+        outstring_exp_two = (
+            "program demo\n"
+            "\n"
+            "\n"
+            "   a = 1\n"
+            "\n"
+            "\n"
+            "   b = 2\n"
+            "\n"
+            "\n"
+            "end program demo\n"
+        )
+
+        self.assert_fprettify_result([], instring, outstring_exp_default)
+        self.assert_fprettify_result(
+            ["--max-consecutive-empty-lines", "0"], instring, outstring_exp_zero
+        )
+        self.assert_fprettify_result(
+            ["--max-consecutive-empty-lines", "2"], instring, outstring_exp_two
+        )
+
     def test_directive(self):
         """
         test deactivate directives '!&' (inline) and '!&<', '!&>' (block)


### PR DESCRIPTION
Resolves https://github.com/pseewald/fprettify/issues/164.

This does not contain any tests, so is currently only intended as a proposal. This solves only one of the several limits with fprettify I need to solve to be able to define the code standard we use.

I can also add that I have a couple of other feature branches in the works at https://github.com/stigh/fprettify, which are cherry-picked into a [development branch](https://github.com/stigh/fprettify/commits/stigs_code_standard/) which hopefully will work towards the code standard we use.

_If I get some kind of indication that this project has a working PR approval process, I intend to put in the extra effort to add the tests required, and the same with the other feature branches I have._