### PR TITLE
Closes #112 Improve speed of number literal matching

### DIFF
--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -463,16 +463,12 @@ F90_CONSTANTS_RE = re.compile(r"\b(" + "|".join((
     "lock_type", "atomic_int_kind", "atomic_logical_kind",
     )) + r")\b", RE_FLAGS)
 
-F90_INT_RE = r"[-+]?[0-9]+"
-F90_FLOAT_RE = r"[-+]?([0-9]+\.[0-9]*|\.[0-9]+)"
-F90_NUMBER_RE = "(" + F90_INT_RE + "|" + F90_FLOAT_RE + ")"
-F90_FLOAT_EXP_RE = F90_NUMBER_RE + r"[eEdD]" + F90_NUMBER_RE
-F90_NUMBER_ALL_RE = "(" + F90_NUMBER_RE + "|" + F90_FLOAT_EXP_RE + ")"
+F90_NUMBER_ALL_RE = r"[-+]?([0-9]+(\.[0-9]*)?|\.[0-9]+)([dDeE][-+]?[0-9]+)?"
 F90_NUMBER_ALL_REC = re.compile(F90_NUMBER_ALL_RE, RE_FLAGS)
 
 ## F90_CONSTANTS_TYPES_RE = re.compile(r"\b" + F90_NUMBER_ALL_RE + "_(" + "|".join([a + r"\b" for a in (
 F90_CONSTANTS_TYPES_RE = re.compile(
-    r"(" + F90_NUMBER_ALL_RE + ")*_(" + "|".join((
+    r"(" + F90_NUMBER_ALL_RE + ")_(" + "|".join((
     ## F2003 iso_fortran_env constants.
     ## F2003 iso_c_binding constants.
     "c_int", "c_short", "c_long", "c_long_long", "c_signed_char",


### PR DESCRIPTION
When applying fprettify using the `--case 1 1 1 1` option, the following code takes a long time to format because of the matching of floating point constants:
```
program main
   implicit none
   real, dimension(2) :: array
   array = [9.23529879234512349823d-02, 3.34099894387578238101e-01]
   print *, sum(array)
end program main
```
On my computer, it takes 6.5 seconds to format. With my simplification of F90_NUMBER_ALL_RE, it still takes 3.2 seconds to format. Finally applying the fix from https://github.com/fortran-lang/fprettify/issues/112, it only takes 0.13 seconds to format.

A part of this PR is already adressed in https://github.com/fortran-lang/fprettify/pull/99, but it appears to be stalled, and I hope that this small fix is easier to review. I noticed the issue because formatting some files at work took > 5 minutes, and a profiler showed that 99% of the time was spent matching these regexes. Apparently this was also noticed by @Jellby and @zaikunzhang in the past, see issue.