### PR TITLE
Add --comment-spacing option

### DIFF
--- a/fprettify/tests/unittests.py
+++ b/fprettify/tests/unittests.py
@@ -144,9 +144,13 @@ class FprettifyUnitTestCase(FprettifyTestCase):
         outstring_exp_strip = ("TYPE mytype\n!  c1\n   !c2\n   INTEGER :: a !  c3\n"
                                "   REAL :: b, & ! c4\n           ! c5\n           ! c6\n"
                                "           d ! c7\nEND TYPE ! c8")
+        outstring_exp_strip_spacing3 = ("TYPE mytype\n!  c1\n   !c2\n   INTEGER :: a   !  c3\n"
+                                         "   REAL :: b, &   ! c4\n           ! c5\n           ! c6\n"
+                                         "           d   ! c7\nEND TYPE   ! c8")
 
         self.assert_fprettify_result([], instring, outstring_exp_default)
         self.assert_fprettify_result(['--strip-comments'], instring, outstring_exp_strip)
+        self.assert_fprettify_result(['--strip-comments', '--comment-spacing', '3'], instring, outstring_exp_strip_spacing3)
 
     def test_directive(self):
         """


### PR DESCRIPTION
Adds `--comment-spacing=N` to control the number of spaces before inline comments when `--strip-comments` is active.

**Usage:** `fprettify --strip-comments --comment-spacing=2 file.f90`

**Default:** 1 space

Includes unit test.