### PR TITLE
Fix indentation realignment for nested blocks

### DIFF
--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -888,7 +888,8 @@ def inspect_ffile_format(infile, indent_size, strict_indent, indent_fypp=False, 
 
         # don't impose indentation for blocked do/if constructs:
         if (IF_RE.search(f_line) or DO_RE.search(f_line)):
-            if (prev_offset != offset or strict_indent):
+            indent_misaligned = indent_size > 0 and offset % indent_size != 0
+            if (prev_offset != offset or strict_indent or indent_misaligned):
                 indents[-1] = indent_size
         else:
             indents[-1] = indent_size


### PR DESCRIPTION
Fixes indentation drift when source has inconsistent offsets in nested do/if blocks.

Nested blocks that are misaligned relative to the configured indent size are now realigned to the proper indent grid.

Single-line change in `inspect_ffile_format`.