### PR TITLE
test: fix test_line_length test failure

### DIFF
--- a/fprettify/tests/unittests.py
+++ b/fprettify/tests/unittests.py
@@ -345,14 +345,20 @@ class FprettifyUnitTestCase(FprettifyTestCase):
         instring_ = "if( min == max.and.min .eq. thres ) one_really_long_function_call_to_hit_the_line_limit(parameter1, parameter2,parameter3,parameter4,parameter5,err) ! this line would be too long"
         outstring = [
             "REAL(KIND=4) :: r, f  !  some reals",
-            "REAL(KIND=4) :: r,f  !  some reals",
+            "REAL(KIND=4) :: r, f\n!  some reals",
             "if (min == max .and. min .eq. thres)",
             "if(   min == max.and.min .eq. thres  )",
             "INQUIRE (14)",
             "INQUIRE (14)",
         ]
         outstring_ = [
-            "if( min == max.and.min .eq. thres ) one_really_long_function_call_to_hit_the_line_limit(parameter1, parameter2,parameter3,parameter4,parameter5,err) ! this line would be too long",
+            "\n".join(
+                [
+                    "if (min == max .and. min .eq. thres) one_really_long_function_call_to_hit_the_line_limit(parameter1, parameter2, parameter3, &",
+                    "                                                                                         parameter4, parameter5, err)",
+                    "! this line would be too long",
+                ]
+            ),
             "if (min == max .and. min .eq. thres) one_really_long_function_call_to_hit_the_line_limit(parameter1, parameter2, parameter3, parameter4, parameter5, err) ! this line would be too long",
         ]
 


### PR DESCRIPTION
Seems like unit tests failures are not propagated to the GitHub workflow, but I see they fail in the latest workflows. Search for `test line length option ... FAIL` in any of the latest workflow logs.

There are other fails too, but I didn't bother with this. Found this when making unit tests for #165.