### PR TITLE
201 test failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.10", "3.11", "3.12"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ For `suite`, you should pick one of the following test suites:
       `./run_tests.py -n ...`
       
 
-### How to deal with test failures
+### How to debug and fix test failures
 
 Test failures are always due to fprettify-formatted code being different than
 expected. To examine what has changed, proceed as follows:

--- a/README.md
+++ b/README.md
@@ -221,6 +221,22 @@ For `suite`, you should pick one of the following test suites:
 - `regular`: for small code bases (executed for every pull request)
 - `cron`: for larger code bases (executed nightly)
 
+Upon running an integration test, `fprettify` is applied in-place to Fortran
+code checked out under `fortran_tests/test_code`. Note that upon running tests
+twice, the output of the first run is the new input of the second run. A reset
+can be achieved by removing `fortran_tests/test_code`. Running integration
+tests multiple times is an important check for idempotency, i.e. that running
+`fprettify` twice doesn't alter results (not yet checked
+automatically).
+
+In case of a test failure, the reported diff just shows input vs. output -- note
+that this diff is usually not related to the test failure, as it shows all
+changes relative to the *unformatted* Fortran code (from an external source).
+To get a diff specifically relative to the *expected* output, you need to run
+integration test first with the reference version of `fprettify`, then with the
+version of `fprettify` causing the failure. Backups of each test run's input
+are stored as `fortran_tests/test_code_in_<date-time>`.
+
 
 ### How to locally run all unit and integration tests:
 
@@ -251,19 +267,21 @@ expected. To examine what has changed, proceed as follows:
   output shows the diff of the actual vs. expected result. 
 - Integration tests: we don't store the expected version of Fortran code,
   instead we compare SHA256 checksums of the actual vs. expected result. The
-  test output shows the diff of the actual result vs. the *previous* version of
-  the code (that is, the version before `fprettify` was applied). Thus, in
-  order to obtain the diff of the actual vs. the *expected* result, the
-  following steps need to be executed:
+  test output shows the diff of the actual result vs. the *original* version of
+  the Fortran code (that is, the version before `fprettify` was applied). In
+  order to get a meaningful diff (specific to the failure), you need to first
+  run the test with the reference version of fprettify (for which the test
+  passes), then with the fprettify version causing the failure.
 
-  1. Run `./run_tests.py -s` followed by the name of the failed test suite. Check
-     the test output for lines mentioning test failures such as: 
-     `Test top-level-dir/subdir/file.f (fprettify.tests.fortrantests.FprettifyIntegrationTestCase) ... checksum FAIL`.
-  2. Check out the reference version of `fprettify` for which the test passes (normally, `develop` branch).
-  3. Run the integration test(s) via `./run_tests.py -n top-level-dir` (replacing
+  More specifically, the following steps need to be executed for a test
+  failure, which is assumed to be reported as 
+  `Test top-level-dir/subdir/file.f (fprettify.tests.fortrantests.FprettifyIntegrationTestCase) ... checksum FAIL`:
+
+  1. Check out the reference version of `fprettify` for which the test passes (normally, `develop` branch).
+  2. Run the integration test(s) via `./run_tests.py -n top-level-dir` (replacing
      `top-level-dir` with the actual directory mentioned in the test output).
-  4. Check out the version of `fprettify` for which the test failed and run the integration tests again.
-  5. Now the `diff` shown in the test output shows the exact changes which caused the test to fail.
+  3. Check out the version of `fprettify` for which the test failed and run the integration tests again.
+  4. Now the `diff` shown in the test output shows the exact changes which caused the test to fail.
 
 If you decide to accept the changes as new test references, proceed as follows:
 - Unit tests: update the expected test result within the respective test method (third argument to function `self.assert_fprettify_result`)

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ tests multiple times is an important check for idempotency, i.e. that running
 `fprettify` twice doesn't alter results (not yet checked
 automatically).
 
-In case of a test failure, the reported diff just shows input vs. output -- note
+In case of a test failure, the reported diff just shows input vs. output. Note
 that this diff is usually not related to the test failure, as it shows all
 changes relative to the *unformatted* Fortran code (from an external source).
 To get a diff specifically relative to the *expected* output, you need to run
@@ -277,7 +277,7 @@ expected. To examine what has changed, proceed as follows:
   failure, which is assumed to be reported as 
   `Test top-level-dir/subdir/file.f (fprettify.tests.fortrantests.FprettifyIntegrationTestCase) ... checksum FAIL`:
 
-  1. Check out the reference version of `fprettify` for which the test passes (normally, `develop` branch).
+  1. Check out the reference version of `fprettify` for which the test passes (normally, `master` branch).
   2. Run the integration test(s) via `./run_tests.py -n top-level-dir` (replacing
      `top-level-dir` with the actual directory mentioned in the test output).
   3. Check out the version of `fprettify` for which the test failed and run the integration tests again.

--- a/fortran_tests/test_results/expected_results
+++ b/fortran_tests/test_results/expected_results
@@ -14,7 +14,7 @@ RosettaCodeData/Task/Abundant,-deficient-and-perfect-number-classifications/Fort
 RosettaCodeData/Task/Ackermann-function/Fortran/ackermann-function.f : 599ed2ad43b48a4fb57831029e4a122a45e380685438bc7a7abead154cfa12f0
 RosettaCodeData/Task/Address-of-a-variable/Fortran/address-of-a-variable.f : 05c4d4bb1358e35769b1adc3362e64dc1011d5a6e4f779289f43bb59f6c11434
 RosettaCodeData/Task/Align-columns/Fortran/align-columns.f : f0cc8c9353edcf6cc9702fe071ef5c7bea77dfe509d239ceda8c782a9ace1206
-RosettaCodeData/Task/Aliquot-sequence-classifications/Fortran/aliquot-sequence-classifications.f : e35ca3f1d7209a33057ad74d782185a68b1dcfb0494dc822ea774c4f878e729a
+RosettaCodeData/Task/Aliquot-sequence-classifications/Fortran/aliquot-sequence-classifications.f : c3dc29164751830ba2ae7314632415f6469d524bffbe74b8441c85ccbcd75bbe
 RosettaCodeData/Task/Amicable-pairs/Fortran/amicable-pairs.f : bca56273936968930bb44f97e1a8f4583d2e2d842ffb9f94c3efc6e9244be7f1
 RosettaCodeData/Task/Animate-a-pendulum/Fortran/animate-a-pendulum.f : 7f59c04d9a1fa07d587609bd45267b915468548e5973dac4e4403ffe1fbb53f2
 RosettaCodeData/Task/Anonymous-recursion/Fortran/anonymous-recursion.f : f9dea9c0fe125cf24b5f28a5f1c1db93193307d4a246caa272802c979e6c1ab7
@@ -412,7 +412,7 @@ RosettaCodeData/Task/Multiple-distinct-objects/Fortran/multiple-distinct-objects
 RosettaCodeData/Task/Multiplication-tables/Fortran/multiplication-tables-1.f : 635b26fabaaf0d1e311a9659e6bcf8c966141d27eb24918ffc16735174651d6b
 RosettaCodeData/Task/Multiplication-tables/Fortran/multiplication-tables-2.f : 3e29dd14a1d171a46749e1c2554b8250e7ef945a396bb97ce1dc2b8403b39df6
 RosettaCodeData/Task/Multiplication-tables/Fortran/multiplication-tables-3.f : 1476bdcb7aa9d50074a583830022740a2fe8951e367d4a03ef67ae24b29db7b4
-RosettaCodeData/Task/Multiplication-tables/Fortran/multiplication-tables-4.f : 4ba6f310b0c8fe99e00507fa0308f172b9faf8a9735fa769029259e3444dbc0b
+RosettaCodeData/Task/Multiplication-tables/Fortran/multiplication-tables-4.f : c7dab4a9cf0f3a1b9c23097ab015b13a67f215a455ad87c8509eea7c69d4b37c
 RosettaCodeData/Task/Multiplication-tables/Fortran/multiplication-tables-5.f : ca83004d898315c8aeca2eb415dcfc2ddf9631401ba93c251cd818b5350741ef
 RosettaCodeData/Task/Multiplication-tables/Fortran/multiplication-tables-6.f : parse error
 RosettaCodeData/Task/Multiplication-tables/Fortran/multiplication-tables-7.f : 42f97f96bccce569c8dd2467a7c905a40e7831ac6a90f7d317490d5c0c62a07b
@@ -527,7 +527,7 @@ RosettaCodeData/Task/Reduced-row-echelon-form/Fortran/reduced-row-echelon-form-1
 RosettaCodeData/Task/Reduced-row-echelon-form/Fortran/reduced-row-echelon-form-2.f : 835ce851ca0ff41d345f754621a70918ce822bccfdb8ee8fb387e6d458ef1017
 RosettaCodeData/Task/Remove-duplicate-elements/Fortran/remove-duplicate-elements.f : 9282a4400871bd66a6073d310bf6b1ee4c0f2df1a41ad1fa78d5a62d0b70b346
 RosettaCodeData/Task/Remove-lines-from-a-file/Fortran/remove-lines-from-a-file-1.f : b977f27a15c367d71070989c9b0dea9d00e952f79491f0d9c555c29afeb6d9c0
-RosettaCodeData/Task/Remove-lines-from-a-file/Fortran/remove-lines-from-a-file-2.f : 82ad6c60028e2c0180768822fd20ded03150119809dee627a7ded6569d17645e
+RosettaCodeData/Task/Remove-lines-from-a-file/Fortran/remove-lines-from-a-file-2.f : 90e2161ec41bc42cf8cfe6ab7a0c50f7475c35161700ec91ff90ccfcd6d8ea2c
 RosettaCodeData/Task/Repeat-a-string/Fortran/repeat-a-string.f : 4d97e4b1da0e2f984ab8011cb7b69366f0b2ae12c270081ccb0808f4167b39fc
 RosettaCodeData/Task/Return-multiple-values/Fortran/return-multiple-values.f : 82dff0d69b2f5c98eabcabc305646335a2c78b419355f30a92fa58553ea11a50
 RosettaCodeData/Task/Reverse-a-string/Fortran/reverse-a-string-1.f : 066ed2e8bd2a95b4f3858490544b0b3c6a7e8dca4aa9798768898d4d911cbc53
@@ -2486,7 +2486,7 @@ RosettaCodeData/Task/Stream-merge/Fortran/stream-merge.f : 3b195c4b4eddc03a48ddb
 RosettaCodeData/Task/String-append/Fortran/string-append-1.f : 056a01c77971f05c7509ea89e70334cc896b853a1500d9c2cefb98ee5928f50c
 RosettaCodeData/Task/String-append/Fortran/string-append-2.f : 48fe63a11f7cb32dd82040cd2d0b8904a35eb78d3d1f90cab5adc7dcca72a69b
 RosettaCodeData/Task/String-interpolation-included-/Fortran/string-interpolation-included-.f : ece1e7f9f43607f9cd763e76a0591c609ea962d818eb241af947662bf5fd0e00
-RosettaCodeData/Task/Subleq/Fortran/subleq.f : 1274bd27e6fb4c6d1bfc272f29ee2d5128463a9917bb17b68f16be959007c6e4
+RosettaCodeData/Task/Subleq/Fortran/subleq.f : 74b6ab790056d5c68e562bdaf0374526dc4e4ad1e48302e200436a32f973c93c
 RosettaCodeData/Task/Substitution-cipher/Fortran/substitution-cipher.f : 00ea6cd0a03b0d50b2538bcf8b08beeb927dd9d21e1e96eb0d442637c40c4fd6
 RosettaCodeData/Task/Sum-to-100/Fortran/sum-to-100-1.f : 0baa956ffce5b75f6c74daa6ba7e3f59f937e512b988869943c2bdcbb3be11f7
 RosettaCodeData/Task/Sum-to-100/Fortran/sum-to-100-2.f : 61b72c885ba7c53e0b499ec7d966b6c50ccad2a737c81eb74ca86b3d9e4c1beb

--- a/fortran_tests/test_results/expected_results
+++ b/fortran_tests/test_results/expected_results
@@ -79,7 +79,7 @@ RosettaCodeData/Task/Averages-Pythagorean-means/Fortran/averages-pythagorean-mea
 RosettaCodeData/Task/Averages-Root-mean-square/Fortran/averages-root-mean-square.f : c91a4cd3ce7dbb9ce8fa753f767a4ccd3fbe17435415839d44338248d2fb14ff
 RosettaCodeData/Task/Averages-Simple-moving-average/Fortran/averages-simple-moving-average.f : 0d491d70d629b0cf7388399eafc6d795eeba199efd6faf0a408e219273bde08d
 RosettaCodeData/Task/Balanced-brackets/Fortran/balanced-brackets.f : 4f6a094ddd888d2c43075746eae3aa02ca8fe6deba0d9f52079d72d692cf2303
-RosettaCodeData/Task/Benfords-law/Fortran/benfords-law-1.f : 56df989a6423e8f846fb3227638fb1117288d47834c62d87feab7a18614a44f4
+RosettaCodeData/Task/Benfords-law/Fortran/benfords-law-1.f : 909c263798e15267b457121b35f8f2def746e01203712f4d4bc0dfe58954741d
 RosettaCodeData/Task/Benfords-law/Fortran/benfords-law-2.f : 0a346752595aa255330184b62aa26a966110e7470640e02097a8da7df42fec4c
 RosettaCodeData/Task/Binary-digits/Fortran/binary-digits.f : 72dbcf0cfd0964746bcf1b0336a864655d925c979e3def6ce3d30855d2b63f4b
 RosettaCodeData/Task/Binary-search/Fortran/binary-search-1.f : 55673449fc1f7030c16bdb8fb4e235c5bb73d8785a31e5150ae224b10ae3a368
@@ -165,7 +165,7 @@ RosettaCodeData/Task/Count-in-octal/Fortran/count-in-octal.f : a8595f6a19be39db1
 RosettaCodeData/Task/Count-occurrences-of-a-substring/Fortran/count-occurrences-of-a-substring.f : cbb0c146faad9720a4e98e0488f9030d4e437e59753a6222fd29ea0f317a34d4
 RosettaCodeData/Task/Create-a-file/Fortran/create-a-file.f : bee7659309b238dd6229d97b5e76b6ae87cc960b282c083c1295364d88d471aa
 RosettaCodeData/Task/Create-a-two-dimensional-array-at-runtime/Fortran/create-a-two-dimensional-array-at-runtime.f : 8581051c5fffeffc4a719c2db968b3588a6143488b435381556f2da1c9099378
-RosettaCodeData/Task/Create-an-HTML-table/Fortran/create-an-html-table.f : c5997233bd75146e2fe0dbc14ec8cae6cb76fff02f4734b35257c0182c5b7e4c
+RosettaCodeData/Task/Create-an-HTML-table/Fortran/create-an-html-table.f : 05f6745526dc1863a0c6a958052dda68b1a3a8360e69457cfb23bc1c0342eed9
 RosettaCodeData/Task/Date-format/Fortran/date-format.f : df4ee40265e75000904e7b3cf27be9c32784d219fbf0d55e1fed6a31d1957667
 RosettaCodeData/Task/Day-of-the-week/Fortran/day-of-the-week.f : 06ed8363f12c7640a59606824a09167bd2cded19e4fa8b1fb67b655553ead132
 RosettaCodeData/Task/Deal-cards-for-FreeCell/Fortran/deal-cards-for-freecell.f : 4ae9b244cc53377dd5f1899691cfee0782d55a7f904ec0a8742aa7b5dc544fea
@@ -550,12 +550,12 @@ RosettaCodeData/Task/SHA-1/Fortran/sha-1.f : 307c0084edfd5bbd04871951fc2f18adb09
 RosettaCodeData/Task/SHA-256/Fortran/sha-256.f : 68e578a715fac0d3a6cbfbbde37986aa07eeea75f9c9de60f47bda20c9015bbe
 RosettaCodeData/Task/Search-a-list/Fortran/search-a-list.f : 54cae29de889febf2f65d182c756bfcb96196d36543c43be2b1b9ffa4ff587fe
 RosettaCodeData/Task/Secure-temporary-file/Fortran/secure-temporary-file.f : 82aab5f017200c04ec6f345b8f6cd9f3290b1057964afb651677b88b36b8f21e
-RosettaCodeData/Task/Semordnilap/Fortran/semordnilap.f : 8f6453f0e197cbb0f6af28e6d2984344d5c71b7061181fb5be5d806ed28a8a92
+RosettaCodeData/Task/Semordnilap/Fortran/semordnilap.f : 7801053824c099d8d81b82f021f2cc61338418b0f39e712f1aad757278df0e72
 RosettaCodeData/Task/Send-email/Fortran/send-email.f : 2db8cfd487ba4099dc245da401fb75ea2cca794e73422c4e220af6a3d973e581
 RosettaCodeData/Task/Sequence-of-non-squares/Fortran/sequence-of-non-squares.f : c1a4894f49b4257ea98b3756691870c73992193309215f36f1fed9a634c9efbc
 RosettaCodeData/Task/Sequence-of-primes-by-Trial-Division/Fortran/sequence-of-primes-by-trial-division.f : d64aea9a2b395d43485ebecab00a0c9ff1d7a68eb54477d9a2c1f3f7984f49e8
 RosettaCodeData/Task/Seven-sided-dice-from-five-sided-dice/Fortran/seven-sided-dice-from-five-sided-dice.f : 0ded21ffb0a10d2bc0e5c9be671389b9babe46a563efffcb1714c4dc889b08d9
-RosettaCodeData/Task/Shell-one-liner/Fortran/shell-one-liner.f : 591a447fb1a50c94eb7f6bcc2f11586ae5eb11300f6a67a5ea2e7c3b5e58042d
+RosettaCodeData/Task/Shell-one-liner/Fortran/shell-one-liner.f : 8f97718493b9620b2f42f416114cb1aa09e58da3ee47fc79a35b560405b27ef4
 RosettaCodeData/Task/Short-circuit-evaluation/Fortran/short-circuit-evaluation.f : 46a20c9ff3c5aacd8bcf53d272ec5e953a2634970fdb780b127da794f333f355
 RosettaCodeData/Task/Sierpinski-carpet/Fortran/sierpinski-carpet.f : db6779f9dde643c9aa799c06b0b113a97837734e72f79607409e5b62c6a3d684
 RosettaCodeData/Task/Sierpinski-triangle/Fortran/sierpinski-triangle.f : db6ef7e8e9191a702164fc8632f072b1d619991b4ab763f0102f2cd8cd9535a7
@@ -670,7 +670,7 @@ RosettaCodeData/Task/Verify-distribution-uniformity-Naive/Fortran/verify-distrib
 RosettaCodeData/Task/Vigen-re-cipher/Fortran/vigen-re-cipher.f : 7c222cec24cf4cf492a7c9c1445e86e3cff268015b5e633da90c50c37a7b80fe
 RosettaCodeData/Task/Wireworld/Fortran/wireworld.f : 566ee0ab64ccf61dccdbda26a9197bfe786af608c3bf02c6a7c32e8ec1eb99ef
 RosettaCodeData/Task/Word-wrap/Fortran/word-wrap-1.f : 95097b84353ef86eb93e9380683a8ff02fefab40fd3f396e3bc2c570c9d73297
-RosettaCodeData/Task/Word-wrap/Fortran/word-wrap-2.f : b5bde57f1b190ffd1db476dcb702fde536751f8ad9e63de4804bdabf38d96e89
+RosettaCodeData/Task/Word-wrap/Fortran/word-wrap-2.f : 6b0030a769ae936aa7bf8af875e242ccf7393790bda321e09b855c39440c85cd
 RosettaCodeData/Task/Write-float-arrays-to-a-text-file/Fortran/write-float-arrays-to-a-text-file-1.f : 14568d07952459593d44455e40f2c5a962ec7d8075401619d8a7aa7982cd4ba8
 RosettaCodeData/Task/Write-float-arrays-to-a-text-file/Fortran/write-float-arrays-to-a-text-file-2.f : 8ebf143220a80aba88806c9a27d33da6d2fa7963be28bb88e43d4a78cbf62b3b
 RosettaCodeData/Task/XML-Input/Fortran/xml-input-1.f : 83cda0a973af665b3d07813b91a2899fad23b5aff5d3203e73904af8104bd4bc
@@ -1902,7 +1902,7 @@ RosettaCodeData/Task/Integer-comparison/Fortran/integer-comparison-2.f : c2e1064
 RosettaCodeData/Task/Integer-comparison/Fortran/integer-comparison-3.f : 6aa50936f2b0de791b9e386de3fc495d818bbe7a7e0adfb0877f77cb70d936ef
 RosettaCodeData/Task/Jensens-Device/Fortran/jensens-device-1.f : d380054d18b2eb9de4570e8dee6d47cf37bbaf9fce462ce623a17140ffd0d89a
 RosettaCodeData/Task/Jensens-Device/Fortran/jensens-device-2.f : 371900846e5bf7e68e3a8d32f9cb7dc2d13f0b063888f38c082f2d64c26ab312
-RosettaCodeData/Task/Logical-operations/Fortran/logical-operations.f : d731cd99840890fe14ffc098a1910ac53163d54d34298c34e5c004eac0310af9
+RosettaCodeData/Task/Logical-operations/Fortran/logical-operations.f : 96f48aad080872749237b2df433007c7d8ad517d7758d358309d8705436fc5dc
 RosettaCodeData/Task/Rename-a-file/Fortran/rename-a-file.f : b1282772aa55739b8442a9e8ee04e9a6c89408f8394ea55b8d6f5a32a4c997f2
 RosettaCodeData/Task/Reverse-words-in-a-string/Fortran/reverse-words-in-a-string.f : 01164158932afdc592f84c439916dcc9ab53689f8a1835f309dcead0f035d37f
 RosettaCodeData/Task/String-case/Fortran/string-case-2.f : 5501427b902a18caeccf8e8b1ffed96545ab0e89487c63e6172e391b3a2d9ec3
@@ -2131,7 +2131,7 @@ RosettaCodeData/Task/Rate-counter/Fortran/rate-counter.f : fd6b448a7a2f53b1de97e
 RosettaCodeData/Task/Remove-duplicate-elements/Fortran/remove-duplicate-elements-1.f : 9282a4400871bd66a6073d310bf6b1ee4c0f2df1a41ad1fa78d5a62d0b70b346
 RosettaCodeData/Task/Remove-duplicate-elements/Fortran/remove-duplicate-elements-2.f : 9734960a3fa2d403e71be11d58dd03eb055f00d629d07f24bdbaf0c2e2a3e820
 RosettaCodeData/Task/Reverse-a-string/Fortran/reverse-a-string-3.f : abf477bfec3f7d53d1c9b607918dd61d2bed0984b9c2f7e2c754dc0fbeb062b2
-RosettaCodeData/Task/Sorting-algorithms-Radix-sort/Fortran/sorting-algorithms-radix-sort.f : 8275b8fdaac3c16ac6500516ff4ac53b670b8fdc07f7a19b6601dfd1927921eb
+RosettaCodeData/Task/Sorting-algorithms-Radix-sort/Fortran/sorting-algorithms-radix-sort.f : 20994aa1011486605996881ad58ec200a1df6b9ed51aafb5ebe798b11770e403
 RosettaCodeData/Task/Sorting-algorithms-Sleep-sort/Fortran/sorting-algorithms-sleep-sort.f : 583ee495dc60dd32c6c0f20ea5caeb6142e6a59ce2c8c8cadd5753418b9462ba
 RosettaCodeData/Task/Special-variables/Fortran/special-variables.f : 73ced0b19ddb14d73878b52775af8a3164724efbc5904a7f2653c7cd192f9df0
 RosettaCodeData/Task/String-case/Fortran/string-case-3.f : 55863eebdcb910e3c489f9e487b8beb21176d58e04bffa017baa38e6d5ffcdc5
@@ -2144,7 +2144,7 @@ RosettaCodeData/Task/Top-rank-per-group/Fortran/top-rank-per-group-1.f : 33bb562
 RosettaCodeData/Task/Top-rank-per-group/Fortran/top-rank-per-group-2.f : 409516fc2ea412eac9fa802e0653f863e869a5428334714f9c81131155766b24
 RosettaCodeData/Task/Van-der-Corput-sequence/Fortran/van-der-corput-sequence.f : f65263a05ae20e53a42b292c6b535cf58fa75f36427214b3041e1210748a6f2f
 RosettaCodeData/Task/Zeckendorf-number-representation/Fortran/zeckendorf-number-representation-1.f : 3953b25eab653b3a37f7192acb6295596ebc61306750b16d5b7d13b4f0489a09
-RosettaCodeData/Task/Zeckendorf-number-representation/Fortran/zeckendorf-number-representation-2.f : 9bb641b7b1cfdf2b29d5c99060b63b58eba66654a27dbddd440e0193745b3b3c
+RosettaCodeData/Task/Zeckendorf-number-representation/Fortran/zeckendorf-number-representation-2.f : c39e5e0395f7df8e6ac2bc4d3688ab5a65a715a83d7974dfe0a7fe0c412cab69
 RosettaCodeData/Task/Zhang-Suen-thinning-algorithm/Fortran/zhang-suen-thinning-algorithm-1.f : 02bcc8a23a4802f6c3461a0c11159fcf7d97cf3ea8b9f997da51df8e3b0ec18e
 RosettaCodeData/Task/Zhang-Suen-thinning-algorithm/Fortran/zhang-suen-thinning-algorithm-2.f : f8ec981ca6c6cab2c08688aafee0120ee680dbeae4564cfceaf91a5d6f780697
 RosettaCodeData/Task/Zhang-Suen-thinning-algorithm/Fortran/zhang-suen-thinning-algorithm-3.f : 10fb85c1921f8d07667ae62a94b5988532c8e8181f99bd3c99f15d9b2ca304ad
@@ -2279,7 +2279,7 @@ RosettaCodeData/Task/100-prisoners/Fortran/100-prisoners.f : 983e232c54fcd8d9799
 RosettaCodeData/Task/15-puzzle-game/Fortran/15-puzzle-game-1.f : c8d1fd9cb9d080ff21dbb698e99949b7f4d9b6da53d493f5ccb58f4f7c184ebe
 RosettaCodeData/Task/15-puzzle-game/Fortran/15-puzzle-game-2.f : f04157c7c4cb0be3b21249577e084be723e730ec38f4785dfed64bedd1d289ec
 RosettaCodeData/Task/15-puzzle-solver/Fortran/15-puzzle-solver-1.f : e272edc58f1ab7818acb4ca0cde6b7938351a8fd8b824fca48c0de5ef8335191
-RosettaCodeData/Task/15-puzzle-solver/Fortran/15-puzzle-solver-2.f : 509a49018cad9c1f191197afeb3833ea7dc02431d7e009afe525c43e32427747
+RosettaCodeData/Task/15-puzzle-solver/Fortran/15-puzzle-solver-2.f : 1cc3768214a0e1072e266bebe3489152f48a4cbf202bf2bd2a41e71dc74190f0
 RosettaCodeData/Task/2048/Fortran/2048-1.f : 16ea6fbcb14ebb2930ba66cd7a5339cb298fd05a120f347ec56fadd45f2af355
 RosettaCodeData/Task/2048/Fortran/2048-2.f : parse error
 RosettaCodeData/Task/21-game/Fortran/21-game-1.f : 5f14c8f47fb0ffcce0e9fa9c0d771dc41a218006faaf153cdedaf3c9fa2b8f84
@@ -2293,7 +2293,7 @@ RosettaCodeData/Task/99-bottles-of-beer/Fortran/99-bottles-of-beer-3.f : dab960e
 RosettaCodeData/Task/A+B/Fortran/a+b-1.f : efa4a3a04b7c89f980398e3312cac13d7260a10d5a58f38af9356028b4dc2a54
 RosettaCodeData/Task/A+B/Fortran/a+b-2.f : 5aca73de2bda25c56404ecd4f443880de517aa39bfe858c7764cd38d5b20a8f5
 RosettaCodeData/Task/ABC-problem/Fortran/abc-problem-1.f : 9729c2df9028f998a7fa68cd4e5604c90ba0783010a257cf61e6f20a501a1c81
-RosettaCodeData/Task/ABC-problem/Fortran/abc-problem-2.f : 7b72cc9206a3252c68e8ee6d1482003d2154f2fb076c99afd723e9ac2eae231a
+RosettaCodeData/Task/ABC-problem/Fortran/abc-problem-2.f : c7d49801d722cab3087709ef5371ee7a829bb018449a6c98e86dbe9bde06a017
 RosettaCodeData/Task/AVL-tree/Fortran/avl-tree.f : b06350bbd936caec813af403a3b03bf416618b928e0d68f3e8aaf0746b5fa85b
 RosettaCodeData/Task/Abelian-sandpile-model/Fortran/abelian-sandpile-model-1.f : b402f36ba106f00732e42043e3c27f6b8d25eaaa43c881eb57742436ecb72cb2
 RosettaCodeData/Task/Abelian-sandpile-model/Fortran/abelian-sandpile-model-2.f : 2152feee11e8e218e053b30447a230b54ba84330e1ce227c84ba9176fce4c872
@@ -2316,11 +2316,11 @@ RosettaCodeData/Task/Biorhythms/Fortran/biorhythms.f : 4f0ebaf47a903deb462272bef
 RosettaCodeData/Task/Boyer-Moore-string-search/Fortran/boyer-moore-string-search.f : 804faaf66d9b49496d7c080499f13ed8799d44bb5d6e562959519e7e92baed0f
 RosettaCodeData/Task/Brazilian-numbers/Fortran/brazilian-numbers.f : e514b0c782dc294d5e9ef8382451115278cfa6c52a3848bab528c74dc45be1bb
 RosettaCodeData/Task/CUSIP/Fortran/cusip.f : 7b92e68ff1762bc1b0c5fdb6dbcc6a959e513b27fe61d4d03676dcaa14c4a30c
-RosettaCodeData/Task/Calculating-the-value-of-e/Fortran/calculating-the-value-of-e.f : 6b400441114621aa6d32130f9f182cd634f0ccf155012ebcd1ddbd57815ccce3
+RosettaCodeData/Task/Calculating-the-value-of-e/Fortran/calculating-the-value-of-e.f : fe01eff5d273b9de763e02fce07ca7d0c7f7181904c79647a21055d00c34e81b
 RosettaCodeData/Task/Cartesian-product-of-two-or-more-lists/Fortran/cartesian-product-of-two-or-more-lists.f : cd6b69c40076b85814b26edcb33f77efaf784321f299fb4964f8c9a2f1e96c80
 RosettaCodeData/Task/Chaos-game/Fortran/chaos-game-1.f : d35adb372bc41fafd520a27038965fba9de59f18dbd22dbb85e4a24563394887
 RosettaCodeData/Task/Chaos-game/Fortran/chaos-game-2.f : 17d39771057f76c5d9046740bb5078e89364e15fff1a55dd565b1b3e7b02db5c
-RosettaCodeData/Task/Cheryls-birthday/Fortran/cheryls-birthday.f : 0d2ad8729f4ffca1d8f63245a03e781b9984b87e1acdcd839577cd61941de4e1
+RosettaCodeData/Task/Cheryls-birthday/Fortran/cheryls-birthday.f : 5bd3de8109063101a97526e0f417bc6fe6ee14554263d067a24ca7119cff16c6
 RosettaCodeData/Task/Chinese-remainder-theorem/Fortran/chinese-remainder-theorem.f : internal error
 RosettaCodeData/Task/Chowla-numbers/Fortran/chowla-numbers.f : 528b17d86909f28e5a8c17483cba4bf855797a6eeb8518f9393dba5e49fc7808
 RosettaCodeData/Task/Compare-a-list-of-strings/Fortran/compare-a-list-of-strings-1.f : e4e79c331bc15ddc49b1af0caca7a7138bef5f98bd50e493659bc40e23492f5f
@@ -2350,7 +2350,7 @@ RosettaCodeData/Task/Determine-if-a-string-has-all-unique-characters/Fortran/det
 RosettaCodeData/Task/Determine-if-a-string-is-squeezable/Fortran/determine-if-a-string-is-squeezable.f : 9bab7d0c744a373eeb1c1a35ecb41005860cc1f601b7cccb72cfc7b78350276a
 RosettaCodeData/Task/Dijkstras-algorithm/Fortran/dijkstras-algorithm.f : e90340059e233e0d7ed746496dc2746340b8eef9b13fa32d0362429afd689622
 RosettaCodeData/Task/Discordian-date/Fortran/discordian-date.f : 6f0d8ee7596e0102ff152e47fcee2437e361cf7412df0bd624bbb01dbbd01103
-RosettaCodeData/Task/Distance-and-Bearing/Fortran/distance-and-bearing.f : bf8a968b0ffdfce0c7ccc2ba5a1daf92901a01d032628af8f09f847bacbb4347
+RosettaCodeData/Task/Distance-and-Bearing/Fortran/distance-and-bearing.f : 7d7829886b2ae46ea14ba8e26493fe9fc385a023d1130eb342319501622ef51a
 RosettaCodeData/Task/Doomsday-rule/Fortran/doomsday-rule.f : 5148ef42c7a86139a591b3b1db840671118b86385fe32a8417b910526abbd6dd
 RosettaCodeData/Task/Emirp-primes/Fortran/emirp-primes.f : parse error
 RosettaCodeData/Task/Eulers-identity/Fortran/eulers-identity.f : b3cf6d7e96d3b452a37d9d8c585620d02b1ca14e88f21e7e7b87258801f94c09
@@ -2358,7 +2358,7 @@ RosettaCodeData/Task/Eulers-sum-of-powers-conjecture/Fortran/eulers-sum-of-power
 RosettaCodeData/Task/Eulers-sum-of-powers-conjecture/Fortran/eulers-sum-of-powers-conjecture-2.f : ebb2d9cb11d8625291b969b7803ebd8d851ca7d6e6516156ea9a19d02130318d
 RosettaCodeData/Task/Execute-Brain-/Fortran/execute-brain--1.f : 008147b30c6b7d8a5f990c9d80efe7c39d845f048941f32fd8aaed46797bc2e5
 RosettaCodeData/Task/Execute-Brain-/Fortran/execute-brain--2.f : 0521bf5368ba92ee0d9528f5a521be25e53e4519f1bc12e95c81f0216404ea3a
-RosettaCodeData/Task/Execute-Brain-/Fortran/execute-brain--3.f : b44a35f600cc8af2d6dbde35de789003665a3fe17a6b9ee1468b18cdb065cc93
+RosettaCodeData/Task/Execute-Brain-/Fortran/execute-brain--3.f : b224f5be361d1f594c7f550062d6f5260d6110d3fdcdba392736c7c07ee28ae5
 RosettaCodeData/Task/Execute-Brain-/Fortran/execute-brain--4.f : 41f50aa8d284d881b0326d682d77fde33f41a5ba6929fb8a1b24dcba61772c52
 RosettaCodeData/Task/Exponentiation-order/Fortran/exponentiation-order.f : 90ff596e832dd827d899d29ed3ec5ecc3d2a7b4e820c691cec1fa3afb00b991d
 RosettaCodeData/Task/Extensible-prime-generator/Fortran/extensible-prime-generator-5.f : parse error
@@ -2366,7 +2366,7 @@ RosettaCodeData/Task/Extensible-prime-generator/Fortran/extensible-prime-generat
 RosettaCodeData/Task/Factorial/Fortran/factorial-3.f : 692b07073d71ab2def3ed1d9e376bf60c12f978bc47d6ae4d72c2b181620f3b6
 RosettaCodeData/Task/Feigenbaum-constant-calculation/Fortran/feigenbaum-constant-calculation.f : 259bcd151204e4a68b9a0d11293349d5a993ee07bf1ab0f8243bf78e606684de
 RosettaCodeData/Task/File-extension-is-in-extensions-list/Fortran/file-extension-is-in-extensions-list-1.f : 2b5c819be194c67a176a76709d2756a81689ffdfc3d3d350be5213f57e15e52f
-RosettaCodeData/Task/File-extension-is-in-extensions-list/Fortran/file-extension-is-in-extensions-list-2.f : b4b2b1377eea43c90a52a0de1a89e6566c6b2e52b6c3d2f73e441879b63d5450
+RosettaCodeData/Task/File-extension-is-in-extensions-list/Fortran/file-extension-is-in-extensions-list-2.f : 09d3bd72fc4b94070a68869592cad3934936560ec01b85041b5d7db33f98dc01
 RosettaCodeData/Task/Find-if-a-point-is-within-a-triangle/Fortran/find-if-a-point-is-within-a-triangle.f : 5317e498983fd298f865d22482a62dfabf3b291634d6c40b16581c30484d2514
 RosettaCodeData/Task/Find-the-intersection-of-two-lines/Fortran/find-the-intersection-of-two-lines.f : c422d84394b91ef5cf8358c0ff1069068eab0de5aafc9c3b4fbf231a8ca6a314
 RosettaCodeData/Task/Floyd-Warshall-algorithm/Fortran/floyd-warshall-algorithm.f : baf60055aa75b1ae2110174a67a137774b0bb876067a64999283256ea95c8c94
@@ -2386,10 +2386,10 @@ RosettaCodeData/Task/Hunt-the-Wumpus/Fortran/hunt-the-wumpus-2.f : 98921cd6288bd
 RosettaCodeData/Task/ISBN13-check-digit/Fortran/isbn13-check-digit.f : c5f45d7f928034ad42f07088f86a116675aa9b04d614ad0703ae119a9a92f94b
 RosettaCodeData/Task/Increasing-gaps-between-consecutive-Niven-numbers/Fortran/increasing-gaps-between-consecutive-niven-numbers.f : d2e7b0fd4c5886dd2df8ed8e5d7cbce4409a9e6b5d4789a599b8d8b88ffb1c01
 RosettaCodeData/Task/Isqrt-integer-square-root-of-X/Fortran/isqrt-integer-square-root-of-x.f : 4540ce0681d4ade5b0c7a4504b1d0fdfe4aeaaa554028a1cb64609952682a25f
-RosettaCodeData/Task/Julia-set/Fortran/julia-set-1.f : 4215ae1889994ee5617a796923c810d4ad3222e29fb3d759eb01d5d9ff612d16
+RosettaCodeData/Task/Julia-set/Fortran/julia-set-1.f : 04ac02a15f9eec466610500198edd412e7a14691712fd667d2640417e4be3e18
 RosettaCodeData/Task/Julia-set/Fortran/julia-set-2.f : 4a5ce09ec6a58592c122aa5993d840dc4283b4f9fd3dff8bf49d8edb559cb192
 RosettaCodeData/Task/Knapsack-problem-0-1/Fortran/knapsack-problem-0-1-1.f : 082a56839ffccd359d32d18f349c475f81b79f453bc982a51961057b096f87b8
-RosettaCodeData/Task/Knapsack-problem-0-1/Fortran/knapsack-problem-0-1-2.f : 6a1df9f3a3de791431b8cfed26c64003a7f928d8840991da4551c2637db0e9d5
+RosettaCodeData/Task/Knapsack-problem-0-1/Fortran/knapsack-problem-0-1-2.f : f028322c83781543930effc44f1bbfe18407719fa1f752516e271f25be64a369
 RosettaCodeData/Task/Knights-tour/Fortran/knights-tour-1.f : 6fb0bd788c151f94b718e3f7680cd84e2500806afd3c01e74b5ca00c839cca5d
 RosettaCodeData/Task/Knights-tour/Fortran/knights-tour-2.f : ec5ca517e10d81685435384853682864e79042026dbb111d7f15e6b9e578005b
 RosettaCodeData/Task/Knights-tour/Fortran/knights-tour-3.f : 16e521b6de25e229df5f2886574e94d6d3a4f7ac0179269e783ba093a8d3d809
@@ -2412,7 +2412,7 @@ RosettaCodeData/Task/Lychrel-numbers/Fortran/lychrel-numbers.f : internal error
 RosettaCodeData/Task/M-bius-function/Fortran/m-bius-function.f : 212a95bf9be8867bd44c96955e10f15393d32943185280e1072125b03a9ca735
 RosettaCodeData/Task/Magic-8-ball/Fortran/magic-8-ball.f : abb8ae94261f7598c827cd2ff88b52d6b3342cc3fed27536eb8a56b16d8542e3
 RosettaCodeData/Task/Matrix-chain-multiplication/Fortran/matrix-chain-multiplication.f : 91817fa14074c857131c54299a6585726d09dfb6946b4e5ca08f4c718a234bbf
-RosettaCodeData/Task/Mayan-calendar/Fortran/mayan-calendar.f : a42bbf5ef4e5cb1596f3be582f8a16c493285ba0a6001af0e412dfc343760983
+RosettaCodeData/Task/Mayan-calendar/Fortran/mayan-calendar.f : 2e38104011fad01c961bb0a89d5b38abb24deb17968a71bdbfe7f2cf6e996c2d
 RosettaCodeData/Task/Mertens-function/Fortran/mertens-function.f : 4811840c0cbb4013378c344cc5eaf7d78b86f621d5cb46be47a7594e033baa9b
 RosettaCodeData/Task/Miller-Rabin-primality-test/Fortran/miller-rabin-primality-test-3.f : 04ced536626dfc510361fc557f21e6806a688eeec2c49fd0a81c3d13134556a0
 RosettaCodeData/Task/Modular-arithmetic/Fortran/modular-arithmetic-1.f : d05c914cdb0eafe533d7dfd94e267735c35673d0bc59cb99f7866c6cc49c89bc
@@ -2434,7 +2434,7 @@ RosettaCodeData/Task/Nested-function/Fortran/nested-function-3.f : ec0cf8fe06c2d
 RosettaCodeData/Task/Numbers-with-equal-rises-and-falls/Fortran/numbers-with-equal-rises-and-falls.f : c0bde305cfab2feaafdabc8ee320dabc7cda3c5c7db7341a87170c5192781168
 RosettaCodeData/Task/Old-Russian-measure-of-length/Fortran/old-russian-measure-of-length.f : 8515b1b8b605be3d32b3757d99ccb3120c7fb6e2984d4d02bc69423ac92deba9
 RosettaCodeData/Task/One-of-n-lines-in-a-file/Fortran/one-of-n-lines-in-a-file.f : 05aa8d237e76b92412820defa409e1ead615d3f97dc80c74e2626cfbe5dbfb66
-RosettaCodeData/Task/Partition-an-integer-x-into-n-primes/Fortran/partition-an-integer-x-into-n-primes.f : 775b5d77c21431b7445b621d916f49e058b5ed15a51fd83b589da77a46225054
+RosettaCodeData/Task/Partition-an-integer-x-into-n-primes/Fortran/partition-an-integer-x-into-n-primes.f : 10da579be2b59d6f1ef59beaaf7c2f92de0fdd5fb3e38cb4692ef40cd74e168c
 RosettaCodeData/Task/Pascal-matrix-generation/Fortran/pascal-matrix-generation-1.f : aaa14761d7c08a0ad5d006b42bf426307062eef93d552c9135fd81696e3de65c
 RosettaCodeData/Task/Pascal-matrix-generation/Fortran/pascal-matrix-generation-2.f : 930277f63f5e0728182047733212f96d9778a9c66cc9957e557b432dee044d3f
 RosettaCodeData/Task/Pathological-floating-point-problems/Fortran/pathological-floating-point-problems-1.f : 302e5e9d1a4dc8e719ff84c874a9ae49292cdeca26b23c8f1bdd3f0c542ea11f
@@ -2443,7 +2443,7 @@ RosettaCodeData/Task/Peaceful-chess-queen-armies/Fortran/peaceful-chess-queen-ar
 RosettaCodeData/Task/Peaceful-chess-queen-armies/Fortran/peaceful-chess-queen-armies-2.f : f95a8a7e2a8f0aaf93ccf1c15b6a73e6d3db01272c0a2d59609674c7698cb437
 RosettaCodeData/Task/Peaceful-chess-queen-armies/Fortran/peaceful-chess-queen-armies-3.f : parse error
 RosettaCodeData/Task/Perfect-shuffle/Fortran/perfect-shuffle.f : b952bd40e0660a31649626e4963b4ea956a1d8bee4a7f5c438e244fcb89a7fed
-RosettaCodeData/Task/Perlin-noise/Fortran/perlin-noise.f : a77231dda02d3b63499c5cb9c32522ab4fea78dffb1548b108d9acd8f205766f
+RosettaCodeData/Task/Perlin-noise/Fortran/perlin-noise.f : e01a39031c7d024d41faf569f2f4a4a04a10f4f8ea9c14d2414ce64b7f5ea9cc
 RosettaCodeData/Task/Polynomial-long-division/Fortran/polynomial-long-division-3.f : 4b8a2ce25f6eafb40536adfacfbc4ebafe9170551e6f6974ffcea4c981ed1b59
 RosettaCodeData/Task/Population-count/Fortran/population-count.f : cea6be52247f4504fca2ab75698413b100349c80424c9f34982e236627e50624
 RosettaCodeData/Task/Prime-conspiracy/Fortran/prime-conspiracy.f : 6580c8d9b52901d31631e60a6b3b71f74c86aa63ba4487009c526eecaf2fa8a4

--- a/fortran_tests/test_results/expected_results
+++ b/fortran_tests/test_results/expected_results
@@ -412,7 +412,7 @@ RosettaCodeData/Task/Multiple-distinct-objects/Fortran/multiple-distinct-objects
 RosettaCodeData/Task/Multiplication-tables/Fortran/multiplication-tables-1.f : 635b26fabaaf0d1e311a9659e6bcf8c966141d27eb24918ffc16735174651d6b
 RosettaCodeData/Task/Multiplication-tables/Fortran/multiplication-tables-2.f : 3e29dd14a1d171a46749e1c2554b8250e7ef945a396bb97ce1dc2b8403b39df6
 RosettaCodeData/Task/Multiplication-tables/Fortran/multiplication-tables-3.f : 1476bdcb7aa9d50074a583830022740a2fe8951e367d4a03ef67ae24b29db7b4
-RosettaCodeData/Task/Multiplication-tables/Fortran/multiplication-tables-4.f : c7dab4a9cf0f3a1b9c23097ab015b13a67f215a455ad87c8509eea7c69d4b37c
+RosettaCodeData/Task/Multiplication-tables/Fortran/multiplication-tables-4.f : c7564e050f7d3265e010696cf043fed75caa3c2ce75ae40814264f8761f3af15
 RosettaCodeData/Task/Multiplication-tables/Fortran/multiplication-tables-5.f : ca83004d898315c8aeca2eb415dcfc2ddf9631401ba93c251cd818b5350741ef
 RosettaCodeData/Task/Multiplication-tables/Fortran/multiplication-tables-6.f : parse error
 RosettaCodeData/Task/Multiplication-tables/Fortran/multiplication-tables-7.f : 42f97f96bccce569c8dd2467a7c905a40e7831ac6a90f7d317490d5c0c62a07b
@@ -527,7 +527,7 @@ RosettaCodeData/Task/Reduced-row-echelon-form/Fortran/reduced-row-echelon-form-1
 RosettaCodeData/Task/Reduced-row-echelon-form/Fortran/reduced-row-echelon-form-2.f : 835ce851ca0ff41d345f754621a70918ce822bccfdb8ee8fb387e6d458ef1017
 RosettaCodeData/Task/Remove-duplicate-elements/Fortran/remove-duplicate-elements.f : 9282a4400871bd66a6073d310bf6b1ee4c0f2df1a41ad1fa78d5a62d0b70b346
 RosettaCodeData/Task/Remove-lines-from-a-file/Fortran/remove-lines-from-a-file-1.f : b977f27a15c367d71070989c9b0dea9d00e952f79491f0d9c555c29afeb6d9c0
-RosettaCodeData/Task/Remove-lines-from-a-file/Fortran/remove-lines-from-a-file-2.f : 90e2161ec41bc42cf8cfe6ab7a0c50f7475c35161700ec91ff90ccfcd6d8ea2c
+RosettaCodeData/Task/Remove-lines-from-a-file/Fortran/remove-lines-from-a-file-2.f : 3011e17c3de9d62038d2dadcd6fdd8e67c73ca8563604ad24511bd1e3298155f
 RosettaCodeData/Task/Repeat-a-string/Fortran/repeat-a-string.f : 4d97e4b1da0e2f984ab8011cb7b69366f0b2ae12c270081ccb0808f4167b39fc
 RosettaCodeData/Task/Return-multiple-values/Fortran/return-multiple-values.f : 82dff0d69b2f5c98eabcabc305646335a2c78b419355f30a92fa58553ea11a50
 RosettaCodeData/Task/Reverse-a-string/Fortran/reverse-a-string-1.f : 066ed2e8bd2a95b4f3858490544b0b3c6a7e8dca4aa9798768898d4d911cbc53
@@ -2316,7 +2316,7 @@ RosettaCodeData/Task/Biorhythms/Fortran/biorhythms.f : 4f0ebaf47a903deb462272bef
 RosettaCodeData/Task/Boyer-Moore-string-search/Fortran/boyer-moore-string-search.f : 804faaf66d9b49496d7c080499f13ed8799d44bb5d6e562959519e7e92baed0f
 RosettaCodeData/Task/Brazilian-numbers/Fortran/brazilian-numbers.f : e514b0c782dc294d5e9ef8382451115278cfa6c52a3848bab528c74dc45be1bb
 RosettaCodeData/Task/CUSIP/Fortran/cusip.f : 7b92e68ff1762bc1b0c5fdb6dbcc6a959e513b27fe61d4d03676dcaa14c4a30c
-RosettaCodeData/Task/Calculating-the-value-of-e/Fortran/calculating-the-value-of-e.f : fe01eff5d273b9de763e02fce07ca7d0c7f7181904c79647a21055d00c34e81b
+RosettaCodeData/Task/Calculating-the-value-of-e/Fortran/calculating-the-value-of-e.f : b747c7de95f42de9097c35211bf15bfbdb25cd073c9a640caabcbb9b53d4ad93
 RosettaCodeData/Task/Cartesian-product-of-two-or-more-lists/Fortran/cartesian-product-of-two-or-more-lists.f : cd6b69c40076b85814b26edcb33f77efaf784321f299fb4964f8c9a2f1e96c80
 RosettaCodeData/Task/Chaos-game/Fortran/chaos-game-1.f : d35adb372bc41fafd520a27038965fba9de59f18dbd22dbb85e4a24563394887
 RosettaCodeData/Task/Chaos-game/Fortran/chaos-game-2.f : 17d39771057f76c5d9046740bb5078e89364e15fff1a55dd565b1b3e7b02db5c
@@ -2389,7 +2389,7 @@ RosettaCodeData/Task/Isqrt-integer-square-root-of-X/Fortran/isqrt-integer-square
 RosettaCodeData/Task/Julia-set/Fortran/julia-set-1.f : 04ac02a15f9eec466610500198edd412e7a14691712fd667d2640417e4be3e18
 RosettaCodeData/Task/Julia-set/Fortran/julia-set-2.f : 4a5ce09ec6a58592c122aa5993d840dc4283b4f9fd3dff8bf49d8edb559cb192
 RosettaCodeData/Task/Knapsack-problem-0-1/Fortran/knapsack-problem-0-1-1.f : 082a56839ffccd359d32d18f349c475f81b79f453bc982a51961057b096f87b8
-RosettaCodeData/Task/Knapsack-problem-0-1/Fortran/knapsack-problem-0-1-2.f : f028322c83781543930effc44f1bbfe18407719fa1f752516e271f25be64a369
+RosettaCodeData/Task/Knapsack-problem-0-1/Fortran/knapsack-problem-0-1-2.f : 861d2a482b8bf81a6edec67338a24104c3383ae6507d246df78ab5f8991e95d7
 RosettaCodeData/Task/Knights-tour/Fortran/knights-tour-1.f : 6fb0bd788c151f94b718e3f7680cd84e2500806afd3c01e74b5ca00c839cca5d
 RosettaCodeData/Task/Knights-tour/Fortran/knights-tour-2.f : ec5ca517e10d81685435384853682864e79042026dbb111d7f15e6b9e578005b
 RosettaCodeData/Task/Knights-tour/Fortran/knights-tour-3.f : 16e521b6de25e229df5f2886574e94d6d3a4f7ac0179269e783ba093a8d3d809
@@ -2443,7 +2443,7 @@ RosettaCodeData/Task/Peaceful-chess-queen-armies/Fortran/peaceful-chess-queen-ar
 RosettaCodeData/Task/Peaceful-chess-queen-armies/Fortran/peaceful-chess-queen-armies-2.f : f95a8a7e2a8f0aaf93ccf1c15b6a73e6d3db01272c0a2d59609674c7698cb437
 RosettaCodeData/Task/Peaceful-chess-queen-armies/Fortran/peaceful-chess-queen-armies-3.f : parse error
 RosettaCodeData/Task/Perfect-shuffle/Fortran/perfect-shuffle.f : b952bd40e0660a31649626e4963b4ea956a1d8bee4a7f5c438e244fcb89a7fed
-RosettaCodeData/Task/Perlin-noise/Fortran/perlin-noise.f : e01a39031c7d024d41faf569f2f4a4a04a10f4f8ea9c14d2414ce64b7f5ea9cc
+RosettaCodeData/Task/Perlin-noise/Fortran/perlin-noise.f : 1db8e2f0188348ac22fc99dcaf850ee8d2b7ea488682142c848b0112d59d9114
 RosettaCodeData/Task/Polynomial-long-division/Fortran/polynomial-long-division-3.f : 4b8a2ce25f6eafb40536adfacfbc4ebafe9170551e6f6974ffcea4c981ed1b59
 RosettaCodeData/Task/Population-count/Fortran/population-count.f : cea6be52247f4504fca2ab75698413b100349c80424c9f34982e236627e50624
 RosettaCodeData/Task/Prime-conspiracy/Fortran/prime-conspiracy.f : 6580c8d9b52901d31631e60a6b3b71f74c86aa63ba4487009c526eecaf2fa8a4

--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -2715,14 +2715,14 @@ def _split_inline_comment(line):
     return code, comment
 
 
-def _detach_inline_comment(idx, indent, lines, orig_lines):
+def _detach_inline_comment(idx, indent, lines, orig_lines, comment_indent=None):
     """Split an inline comment into its own line keeping indentation metadata."""
     splitted = _split_inline_comment(lines[idx])
     if not splitted:
         return False
 
     code_line, comment_line = splitted
-    base_indent = indent[idx]
+    base_indent = indent[idx] if comment_indent is None else comment_indent
 
     lines[idx] = code_line
     orig_lines[idx] = code_line
@@ -2805,8 +2805,11 @@ def write_formatted_line(
                 _insert_split_chunks(
                     idx, split_lines, indent, indent_size, lines, orig_lines
                 )
+                label = label_use  # restore label for first split line
                 continue
-            if _detach_inline_comment(idx, indent, lines, orig_lines):
+            comment_ind = max(0, padding - len(label_use)) if label_use else None
+            if _detach_inline_comment(idx, indent, lines, orig_lines, comment_indent=comment_ind):
+                label = label_use  # restore label for detached line
                 continue
 
         if rendered_length <= llength:
@@ -2836,7 +2839,12 @@ def write_formatted_line(
                 line_nr,
             )
         else:
-            outfile.write(orig_line)
+            if label_use and not orig_line.lstrip().startswith(label_use.strip()):
+                outfile.write(
+                    "!$ " * is_omp_conditional + label_use + " " * padding + stripped_line
+                )
+            else:
+                outfile.write(orig_line)
             log_message(
                 LINESPLIT_MESSAGE + " (limit: " + str(llength) + ")",
                 "warning",

--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -1394,7 +1394,7 @@ def inspect_ffile_format(
         # don't impose indentation for blocked do/if constructs:
         if IF_RE.search(f_line) or DO_RE.search(f_line):
             indent_misaligned = indent_size > 0 and offset % indent_size != 0
-            if prev_offset != offset or strict_indent or indent_misaligned:
+            if prev_offset != offset or strict_indent:  # or indent_misaligned:
                 indents[-1] = indent_size
         else:
             indents[-1] = indent_size

--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -2808,7 +2808,9 @@ def write_formatted_line(
                 label = label_use  # restore label for first split line
                 continue
             comment_ind = max(0, padding - len(label_use)) if label_use else None
-            if _detach_inline_comment(idx, indent, lines, orig_lines, comment_indent=comment_ind):
+            if _detach_inline_comment(
+                idx, indent, lines, orig_lines, comment_indent=comment_ind
+            ):
                 label = label_use  # restore label for detached line
                 continue
 
@@ -2841,7 +2843,10 @@ def write_formatted_line(
         else:
             if label_use and not orig_line.lstrip().startswith(label_use.strip()):
                 outfile.write(
-                    "!$ " * is_omp_conditional + label_use + " " * padding + stripped_line
+                    "!$ " * is_omp_conditional
+                    + label_use
+                    + " " * padding
+                    + stripped_line
                 )
             else:
                 outfile.write(orig_line)

--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -2962,7 +2962,7 @@ def get_arg_parser(args={}):
         "--line-length",
         type=int,
         default=132,
-        help="column after which a line should end, viz. -ffree-line-length-n for GCC",
+        help="column after which a line should end, viz. -ffree-line-length-n for GCC. Set to 0 to disable breaking of long lines.",
     )
     parser.add_argument(
         "-w",

--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -2288,9 +2288,11 @@ def reformat_ffile_combined(
         lines = remove_trailing_whitespace(lines)
 
         # need to shift indents if label wider than first indent
+        label_shift = 0
         if label and impose_indent:
             if indent[0] < len(label):
-                indent = [ind + len(label) - indent[0] for ind in indent]
+                label_shift = len(label) - indent[0]
+                indent = [ind + label_shift for ind in indent]
 
         allow_auto_split = auto_format and (impose_whitespace or impose_indent)
         write_formatted_line(
@@ -2307,6 +2309,8 @@ def reformat_ffile_combined(
             orig_filename,
             stream.line_nr,
             allow_split=allow_auto_split,
+            f_line=f_line,
+            label_shift=label_shift,
         )
 
         # rm subsequent blank lines
@@ -2670,15 +2674,29 @@ def _auto_split_line(line, ind_use, llength, indent_size):
     return new_lines
 
 
-def _insert_split_chunks(idx, split_lines, indent, indent_size, lines, orig_lines):
+def _aligned_chunk_indents(
+    f_line, lines, idx, split_lines, indent, indent_size, filename, line_nr
+):
+    """
+    Compute indents for auto-split chunks replacing line `idx`, matching the
+    alignment that F90Aligner will produce when the split result is
+    reformatted. This keeps auto line-splitting idempotent.
+    """
+    new_lines = lines[:idx] + split_lines + lines[idx + 1 :]
+    aligner = F90Aligner(filename)
+    aligner.process_lines_of_fline(f_line, new_lines, indent_size, line_nr)
+    rel_indents = aligner.get_lines_indent()
+    base = indent[0]
+    return [indent[idx]] + [
+        base + rel_indents[idx + pos] for pos in range(1, len(split_lines))
+    ]
+
+
+def _insert_split_chunks(idx, split_lines, indent, new_indents, lines, orig_lines):
     """Replace the original line at `idx` with its split chunks and matching indents."""
-    base_indent = indent[idx]
     indent.pop(idx)
     lines.pop(idx)
     orig_lines.pop(idx)
-
-    follow_indent = base_indent + indent_size
-    new_indents = [base_indent] + [follow_indent] * (len(split_lines) - 1)
 
     for new_line, new_indent in reversed(list(zip(split_lines, new_indents))):
         lines.insert(idx, new_line)
@@ -2748,6 +2766,8 @@ def write_formatted_line(
     filename,
     line_nr,
     allow_split,
+    f_line="",
+    label_shift=0,
 ):
     """Write reformatted line to file"""
 
@@ -2802,12 +2822,25 @@ def write_formatted_line(
         if needs_split:
             split_lines = _auto_split_line(line, ind_use, llength, indent_size)
             if split_lines:
+                chunk_indents = _aligned_chunk_indents(
+                    f_line,
+                    lines,
+                    idx,
+                    split_lines,
+                    indent,
+                    indent_size,
+                    filename,
+                    line_nr,
+                )
                 _insert_split_chunks(
-                    idx, split_lines, indent, indent_size, lines, orig_lines
+                    idx, split_lines, indent, chunk_indents, lines, orig_lines
                 )
                 label = label_use  # restore label for first split line
                 continue
-            comment_ind = max(0, padding - len(label_use)) if label_use else None
+            # the detached comment becomes a standalone comment line, so it
+            # must get the indent a reformat gives such a line: the block
+            # indent without any shift that makes room for a statement label
+            comment_ind = max(0, indent[idx] - label_shift)
             if _detach_inline_comment(
                 idx, indent, lines, orig_lines, comment_indent=comment_ind
             ):

--- a/fprettify/tests/fortrantests.py
+++ b/fprettify/tests/fortrantests.py
@@ -180,11 +180,10 @@ def normalize_line(line):
     Normalize fortran line in a way that resulting string should be the same
     whether fprettify has been applied or not.
     """
-    line_out = re.sub(
-        r"\n{3,}", r"\n\n", line.lower().replace(" ", "").replace("\t", "")
-    )
-    # fprettify might add missing ampersands when splitting string
-    line_out = re.sub("^&", "", line_out, flags=re.MULTILINE)
+    # fprettify might add missing ampersands when splitting string:
+    line_out = re.sub("^\s*&", "", line.lower(), flags=re.MULTILINE)
+    # remove all whitespace characters (including newline)
+    line_out = re.sub(r"\s", r"", line.lower())
     return line_out
 
 
@@ -280,7 +279,7 @@ def add_test_method(testcase, fpath, ffile, args):
         orig_stripped = normalize_line(instring)
         new_stripped = normalize_line(outstring)
 
-        testcase.assertMultiLineEqual(
+        testcase.assertEqual(
             orig_stripped,
             new_stripped,
             "fprettify caused changes other than whitespace or lower/upper case",

--- a/fprettify/tests/fortrantests.py
+++ b/fprettify/tests/fortrantests.py
@@ -182,8 +182,9 @@ def normalize_line(line):
     """
     # fprettify might add missing ampersands when splitting string:
     line_out = re.sub("^\s*&", "", line.lower(), flags=re.MULTILINE)
+    line_out = re.sub("&\s*$", "", line_out, flags=re.MULTILINE)
     # remove all whitespace characters (including newline)
-    line_out = re.sub(r"\s", r"", line.lower())
+    line_out = re.sub(r"\s", r"", line_out)
     return line_out
 
 

--- a/fprettify/tests/fortrantests.py
+++ b/fprettify/tests/fortrantests.py
@@ -164,6 +164,8 @@ def generate_suite(suite=None, name=None):
                 os.chdir(TEST_EXT_DIR)
 
                 if not os.path.isdir(code["path"]):
+                    # code is reinitialized only if path doesn't exist
+                    # this allows iterative debugging to compare changes between different versions of fprettify
                     print(f"obtaining {key} ...")
                     exec(code["obtain"])
             finally:

--- a/fprettify/tests/unittests.py
+++ b/fprettify/tests/unittests.py
@@ -768,6 +768,11 @@ ${worktype}$, &
         outstring = "print *, 'hello'\n1003 FORMAT(2(1x, i4), 5x, '-', 5x, '-', 3x, '-', 5x, '-', 5x, '-', 8x, '-', 3x, &\n            1p, 2(1x, d10.3))"
         self.assert_fprettify_result([], instring, outstring)
 
+    def test_statement_label_auto_break(self):
+        instring = "1003  FORMAT(2(1x, i4), 5x, '-', 5x, '-', 3x, '-', 5x, '-', 5x, '-', 8x, '-', 3x, 1p, 2(1x, d10.3)) ! comment"
+        outstring = "1003  FORMAT(2(1x, i4), 5x, '-', 5x, '-', 3x, '-', 5x, '-', 5x, '-', 8x, '-', 3x, 1p, 2(1x, d10.3))\n! comment"
+        self.assert_fprettify_result(["--line-length=10"], instring, outstring)
+
     def test_multiline_str(self):
 
         instring = []

--- a/fprettify/tests/unittests.py
+++ b/fprettify/tests/unittests.py
@@ -770,7 +770,9 @@ ${worktype}$, &
 
     def test_statement_label_auto_break(self):
         instring = "1003  FORMAT(2(1x, i4), 5x, '-', 5x, '-', 3x, '-', 5x, '-', 5x, '-', 8x, '-', 3x, 1p, 2(1x, d10.3)) ! comment"
-        outstring = "1003  FORMAT(2(1x, i4), 5x, '-', 5x, '-', 3x, '-', 5x, '-', 5x, '-', 8x, '-', 3x, 1p, 2(1x, d10.3))\n! comment"
+        # the comment does not fit within the line length limit at any
+        # indentation, so it ends up right-aligned at the limit (idempotent)
+        outstring = "1003  FORMAT(2(1x, i4), 5x, '-', 5x, '-', 3x, '-', 5x, '-', 5x, '-', 8x, '-', 3x, 1p, 2(1x, d10.3))\n ! comment"
         self.assert_fprettify_result(["--line-length=10"], instring, outstring)
 
     def test_multiline_str(self):


### PR DESCRIPTION
This is work in progress to fix current test failures introduced by #186.

- I removed `indent_misaligned` condition because it doesn't make much sense to me (as commented already in https://github.com/fortran-lang/fprettify/pull/186#discussion_r2838226511)
- adapted checks for non-whitespace changes in tests to take new auto break feature into account
- added a unit test which is expected to fail due to an issue with statement labels being removed

@zandivx Could you please fix the unit test failure? Then all other tests should pass as well. You can push to this pr, or create a new pr, as you prefer.

Could you also review this pr (in particular, if you agree with removing `indent_misaligned` condition)?