### PR TITLE
Fixing `--enable-replacements`, #153 and #168 respectively

### DIFF
--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -2234,17 +2234,18 @@ def reformat_ffile_combined(
                 lines, is_special, orig_filename, stream.line_nr
             )
 
-            linebreak_pos = get_linebreak_pos(
-                lines, not indent_fypp, orig_filename, stream.line_nr
-            )
-
             f_line = f_line.strip(" ")
 
             if impose_replacements:
                 f_line = replace_relational_single_fline(f_line, cstyle)
+                lines = [replace_relational_single_fline(l, cstyle) for l in lines]
 
             if impose_case:
                 f_line = replace_keywords_single_fline(f_line, case_dict)
+
+            linebreak_pos = get_linebreak_pos(
+                lines, not indent_fypp, orig_filename, stream.line_nr
+            )
 
             if impose_whitespace:
                 lines = format_single_fline(

--- a/fprettify/tests/unittests.py
+++ b/fprettify/tests/unittests.py
@@ -384,7 +384,7 @@ class FprettifyUnitTestCase(FprettifyTestCase):
             "'==== heading",
             "if (vtk%my_rank .eq. 0) write (vtk%filehandle_par, '(\"<DataArray",
             '\'("</Collection>",',
-            "if (abc(1) .lt. -bca .or. &\n qwe .gt. ewq) then",
+            "if (abc(1)<=-bca .or. &\n qwe .gt. ewq) then",
         ]
         f_outstring = [
             "if (min .lt. max .and. min .lt. thres)",
@@ -396,7 +396,7 @@ class FprettifyUnitTestCase(FprettifyTestCase):
             "'==== heading",
             "if (vtk%my_rank .eq. 0) write (vtk%filehandle_par, '(\"<DataArray",
             '\'("</Collection>",',
-            "if (abc(1) .lt. -bca .or. &\n    qwe .gt. ewq) then",
+            "if (abc(1) .le. -bca .or. &\n    qwe .gt. ewq) then",
         ]
         c_outstring = [
             "if (min < max .and. min < thres)",
@@ -408,7 +408,7 @@ class FprettifyUnitTestCase(FprettifyTestCase):
             "'==== heading",
             "if (vtk%my_rank == 0) write (vtk%filehandle_par, '(\"<DataArray",
             '\'("</Collection>",',
-            "if (abc(1) < -bca .or. &\n    qwe > ewq) then",
+            "if (abc(1) <= -bca .or. &\n    qwe > ewq) then",
         ]
         for i in range(0, len(instring)):
             self.assert_fprettify_result(


### PR DESCRIPTION
When relational operations are replaced (across split lines), the splitting is incorrect. This adds a fix and a single unittest.
This uses the suggestion from #168 as the much nicer solution.

Fixing #153 and #168