### PR TITLE
Separate treatment of intrinsic statements and control constructs

### DIFF
--- a/fprettify/__init__.py
+++ b/fprettify/__init__.py
@@ -1573,21 +1573,22 @@ def format_single_fline(
         "multdiv": 5,  # 5: arithm. operators multiply and divide
         "print": 6,  # 6: print / read statements
         "type": 7,  # 7: select type components
-        "intrinsics": 8,  # 8: intrinsics
+        "intrinsics": 8,  # 8: intrinsics (control-flow keywords: if, do while, case, …)
         "decl": 9,  # 9: declarations
         "concat": 10,  # 10: string concatenation
+        "intrinsic_stmts": 11,  # 11: intrinsic statements (allocate, open, close, …)
     }
 
     if whitespace == 0:
-        spacey = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        spacey = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     elif whitespace == 1:
-        spacey = [1, 1, 1, 1, 0, 0, 1, 0, 1, 1, 0]
+        spacey = [1, 1, 1, 1, 0, 0, 1, 0, 1, 1, 0, 1]
     elif whitespace == 2:
-        spacey = [1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 0]
+        spacey = [1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 0, 1]
     elif whitespace == 3:
-        spacey = [1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0]
+        spacey = [1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1]
     elif whitespace == 4:
-        spacey = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        spacey = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
     else:
         raise NotImplementedError("unknown value for whitespace")
 
@@ -1711,11 +1712,12 @@ def add_whitespace_charwise(line, spacey, scope_parser, format_decl, filename, l
                     or re.search(
                         SOL_STR + r"(TYPE|CLASS)\s+IS\s*$", line[:pos], RE_FLAGS
                     )
-                    or re.search(
-                        r"(?<!%)\b" + INTR_STMTS_PAR + r"\s*$", line[:pos], RE_FLAGS
-                    )
                 ):
                     sep1 = 1 * spacey[8]
+                elif re.search(
+                    r"(?<!%)\b" + INTR_STMTS_PAR + r"\s*$", line[:pos], RE_FLAGS
+                ):
+                    sep1 = 1 * spacey[11]
 
             # format closing delimiters
             else:
@@ -2900,6 +2902,7 @@ def process_args(args):
         ws_dict["type"] = args.whitespace_type
         ws_dict["intrinsics"] = args.whitespace_intrinsics
         ws_dict["concat"] = args.whitespace_concat
+        ws_dict["intrinsic_stmts"] = args.whitespace_intrinsic_stmts
         return ws_dict
 
     args_out = {}
@@ -3055,7 +3058,15 @@ def get_arg_parser(args={}):
         nargs="?",
         default="None",
         const=True,
-        help="boolean, en-/disable whitespace for intrinsics like if/write/close",
+        help="boolean, en-/disable whitespace for intrinsic keywords like if/do while/case",
+    )
+    parser.add_argument(
+        "--whitespace-intrinsic-stmts",
+        type=str2bool,
+        nargs="?",
+        default="None",
+        const=True,
+        help="boolean, en-/disable whitespace between intrinsic statements (allocate, open, close, …) and opening '('",
     )
     parser.add_argument(
         "--whitespace-concat",

--- a/fprettify/tests/unittests.py
+++ b/fprettify/tests/unittests.py
@@ -95,6 +95,28 @@ class FprettifyUnitTestCase(FprettifyTestCase):
         self.assert_fprettify_result([], instring_in_string, instring_in_string)
         self.assert_fprettify_result([], instring_in_comment, instring_in_comment)
 
+    def test_whitespace_intrinsic_stmts(self):
+        """test --whitespace-intrinsic-stmts: controls space before ( for allocate/open/close etc.,
+        independently of control-flow keywords like if/do while/case"""
+
+        # default (-w 2): both keywords and intrinsic stmts get a space
+        instring = "if(x)then\nallocate(a(10))\nopen(unit=1,file='f')\nclose(1)\nend if"
+        outstring_default = "if (x) then\n   allocate (a(10))\n   open (unit=1, file='f')\n   close (1)\nend if"
+        self.assert_fprettify_result([], instring, outstring_default)
+
+        # disable only intrinsic stmts: allocate/open/close lose space, if keeps it
+        outstring_no_stmts = "if (x) then\n   allocate(a(10))\n   open(unit=1, file='f')\n   close(1)\nend if"
+        self.assert_fprettify_result(
+            ["--whitespace-intrinsic-stmts", "false"], instring, outstring_no_stmts
+        )
+
+        # disable only keywords: if loses space, allocate/open/close keep it
+        # (end if also loses its space since spacey[8] also controls END <keyword> spacing)
+        outstring_no_kw = "if(x) then\n   allocate (a(10))\n   open (unit=1, file='f')\n   close (1)\nendif"
+        self.assert_fprettify_result(
+            ["--whitespace-intrinsics", "false"], instring, outstring_no_kw
+        )
+
     def test_indent(self):
         """simple test for indent options -i in [0, 3, 4]"""
 


### PR DESCRIPTION
To get a different treatment of 
if (a==b)...
and
allocate(a(1:10))
w.r.t. additional whitespace between keyword and opening parenthesis, we add here a new option:
--whitespace-intrinsic-stmts
